### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ COCOAPODS
 ENGLISH
 =============
 
-###Easy library to fetch and edit data from and to plists on the fly (XCode)
+###Easy library to fetch and edit data from and to plists on the fly (Xcode)
 
 
 ---
@@ -112,7 +112,7 @@ N.B. If you want to save sensible data DON'T USE PLISTS! Use CoreData instead or
 
 ITALIANO
 =============
-###Semplice libreria per recuperare dati da file plist e modificarli al volo (XCode)
+###Semplice libreria per recuperare dati da file plist e modificarli al volo (Xcode)
 
 
 ---


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
